### PR TITLE
Posterior predictive

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,15 +2,18 @@ name: null                          # Our env was made with --prefix
 channels:
   - conda-forge                     # third party stuff
   - defaults
+  - etamsen
 dependencies:
-  - python=3.7
-  - pip
+  #- python=3.7
+  - pip:
+    - probeye==1.0.6
+    - rdflib==5.0.0
   - matplotlib
-  - pymc3=3.9.3
   - doit
   - pyyaml
   - mkl
   - mkl-service
+  - fenics_concrete
 #  - flake8
 #  - sphinx
 #  - sphinx_rtd_theme

--- a/usecases/Concrete/Calibration/E_modul_calibration.py
+++ b/usecases/Concrete/Calibration/E_modul_calibration.py
@@ -1,8 +1,10 @@
 # -- PKM TUM -- atul.agrawal@tum.de -- #
-
-from misc import load_experimental_data
+# local imports
+from usecases.Concrete.Prediction.three_point_bending_example import three_point_bending_example
+from misc import load_experimental_data, PosteriorPredictive
 import numpy as np
 import matplotlib.pyplot as plt
+import seaborn as sns
 
 from probeye.definition.forward_model import ForwardModelBase
 from probeye.definition.sensor import Sensor
@@ -17,12 +19,13 @@ from probeye.postprocessing.sampling import create_trace_plot, create_pair_plot
 skip_last = 145
 skip_init = 330
 experiment_name = 'Wolf 8.2 Probe 1'
-exp_output = load_experimental_data(experiment_name,skip_init,skip_last)
+path = '../knowledgeGraph/emodul/E-modul-processed-data/processeddata/processed_Wolf_8_2_Probe_1.csv'
+exp_output = load_experimental_data(experiment_name,skip_init,skip_last, path=path)
 plt.plot(exp_output['stress'],exp_output['displacement']/exp_output['height'])  # checking loading data
 
 # -- Set Numerical values
 # "uninformed" Normal prior for the E modulus
-loc_E = 100
+loc_E = 100 # kN/mm2
 scale_E = 100 # this can be inferred too
 
 # Uniform prior for experimental noise/model discrepancy
@@ -73,7 +76,29 @@ solver = PyroSolver(problem)
 pos = solver.run_mcmc(n_steps=500,n_initial_steps=100)
 mcmc_pyro = solver.raw_results
 mcmc_pyro.summary()
+
+# -- Storing in KG with RDF
+# TODO
+
 # -- Visualisation
 create_trace_plot(pos, problem)
 
 create_pair_plot(pos,problem,focus_on_posterior=True)
+
+# -- Posterior Predictive
+# ---- query KG
+# TODO
+
+# ---- posterior predictive values
+nu = 0.2
+E_pos = 1000*solver.raw_results.get_samples()['E'].numpy() # N/mm2
+three_point = three_point_bending_example()
+pos_pred = PosteriorPredictive(three_point.run, known_input_solver=nu,parameter=E_pos)
+mean, sd = pos_pred.get_stats(samples=20)
+# ---- visualize posterior predictive
+posterior_pred_samples = pos_pred._samples
+np.save('./post_pred.npy',posterior_pred_samples)
+sns.kdeplot(posterior_pred_samples)
+plt.xlabel('stress in x-direction')
+
+

--- a/usecases/Concrete/Calibration/misc.py
+++ b/usecases/Concrete/Calibration/misc.py
@@ -7,11 +7,13 @@ from pathlib import Path
 import sys
 
 baseDir1 = Path(__file__).resolve().parents[1]
-sys.path.append(os.path.join(os.path.join(baseDir1,'knowledgeGraph'),'emodul'))
+sys.path.append(os.path.join(os.path.join(baseDir1, 'knowledgeGraph'), 'emodul'))
+sys.path.append(os.path.join(baseDir1, 'Data'))
 
 import emodul_query
 
-def load_experimental_data(exp_name, skip_init, skip_last):
+
+def load_experimental_data(exp_name, skip_init, skip_last, KG=False, path=None):
     """
     Function to interact with the knowledge graph database and get experimental data
     # TODO : Clarify the units used. Now Force :kN, dispalcement : mm
@@ -24,14 +26,22 @@ def load_experimental_data(exp_name, skip_init, skip_last):
         output (dict):
             The experiment values with keys as 'height' (int), 'diameter' (int), 'displacement' (np.array), 'stress' (np.array)
     """
-
-    df = pd.read_csv(emodul_query.input_emodul_data_for_calibration(exp_name)['processedDataPath'], skipfooter=skip_last)
+    if KG is True:
+        df = pd.read_csv(emodul_query.input_emodul_data_for_calibration(exp_name)['processedDataPath'],
+                         skipfooter=skip_last)
+    if KG is not True:  # manually passing the processed data path
+        df = pd.read_csv(path, skipfooter=skip_last)
     df = df.drop(labels=range(0, skip_init), axis=0)
 
+    if KG is True:
+        dia = emodul_query.input_emodul_data_for_calibration(exp_name)['specimenDiameter']
+        height = emodul_query.input_emodul_data_for_calibration(exp_name)['specimenLength']
+    if KG is not True:
+        dia = 98.6
+        height = 300.2
+
     df['displacement'] = (df['Transducer 1[mm]'] + df['Transducer 2[mm]'] + df['Transducer 3[mm]']) / 3
-    dia = emodul_query.input_emodul_data_for_calibration(exp_name)['specimenDiameter']
     df['stress'] = df['Force [kN]'] / (np.pi * (dia / 2) ** 2)
-    height = emodul_query.input_emodul_data_for_calibration(exp_name)['specimenLength']
 
     output = {
         'height': height,
@@ -39,3 +49,78 @@ def load_experimental_data(exp_name, skip_init, skip_last):
         'displacement': np.array(df['displacement']),
         'stress': np.array(df['stress'])}
     return output
+
+class PosteriorPredictive:
+    """
+    Will be depricated when it is integrated in probeye
+    """
+
+    def __init__(self, forward_solver, known_input_solver, parameter = None, query_kg = None):
+
+        """
+        TODO: Add option to add point estimates of parameters if forward solver is expensive
+
+        Parameters
+        ----------
+        forward_solver :
+            Defines the forward model. Check out forward_model.py to see a template for
+            the forward model definition if needed. The user will then have to derive his own
+            forward model from that base class. Examples can be found in the package
+            directory tests/integration_tests. user can also specify his/her own forward model,
+            which just takes in input.
+            Should be wrapped in a fucntion which takes in two args. arg1 = random input, arg2 = known input
+        parameter :
+            An array of samples. Currently parameters dont support a distrutbion, just MCMC samples. To get an approx.
+            for parameter dist, we need VI based posterior approx
+        known_input_solver :
+            Pass known input value to the solver in whichever format the forward_solve object needs.
+        query_kg :
+            A query script (with appropriate arguments) which outputs the sample or the stats of the inferred parameter
+            needed for the forward model
+        """
+
+        #assert (parameter == np.array), "Parameter needs to be np.ndarray"
+        #assert parameter.shape[1] == 1, "Currently support only 1 parameter"
+
+        self._forward_solver = forward_solver
+        if parameter is not None:
+            self._parameter = parameter
+        if query_kg is not None:
+            # run the query script
+            para = query_kg()
+            self._parameter = para
+        self._known_input = known_input_solver
+        self._mean = None
+        self._std = None
+        self._samples = None
+
+    def get_stats(self, samples: int) -> tuple:
+        """
+        Returns mean and s.d of the posterior predictive. Simple Monte Carlo based approximation
+
+        Parameters
+        ----------
+        samples :
+
+        Returns
+        -------
+
+        """
+        # Monte carlo step
+        output = []
+        for i in range(0, samples):
+            y = self._forward_solver(self._parameter[i], self._known_input)
+            output.append(y)
+
+        # get the posterior pred stats
+        mean = np.mean(output, axis=0)
+        sd = np.std(output, axis=0)
+
+        self._mean = mean
+        self._std = sd
+        self._samples = output
+        return mean, sd
+
+    def plot_posterior_predictive(self):
+        raise NotImplementedError(
+            "...")

--- a/usecases/Concrete/Prediction/three_point_bending_example.py
+++ b/usecases/Concrete/Prediction/three_point_bending_example.py
@@ -2,61 +2,110 @@ import dolfin as df
 import fenics_concrete
 
 
-def three_point_bending_example(E, nu):
-    """Example of a linear elastic three point bending test
+class three_point_bending_example(object):
+    def run(self, E, nu):
+        """Example of a linear elastic three point bending test
 
-    Parameters
-    ----------
-        E : float
-            Young's modulus in N/mm²
-        nu : float
-            Poisson's ratio
+            Parameters
+            ----------
+                E : float
+                    Young's modulus in N/mm²
+                nu : float
+                    Poisson's ratio
 
-    Returns
-    -------
-        stress_in_x : float
-            Stress in x direction in the center at the bottom, where the maximum stress is expected
-    """
-    # setting up the simulation parameters
-    parameters = fenics_concrete.Parameters()  # using the current default values
-    # input values for the material
-    parameters['E'] = E
-    parameters['nu'] = nu
-    # definition of the beam and mesh
-    parameters['dim'] = 3
-    parameters['mesh_density'] = 4  # number of elements in vertical direction
-    parameters['height'] = 300  # in mm
-    parameters['length'] = 2000  # in mm
-    parameters['width'] = 150  # in mm
-    parameters['log_level'] = 'WARNING'
-    # displacement load in the center of the beam
-    displacement = -10  # displacement load in the center of the beam in mm
+            Returns
+            -------
+                stress_in_x : float
+                    Stress in x direction in the center at the bottom, where the maximum stress is expected
+            """
+        # setting up the simulation parameters
+        parameters = fenics_concrete.Parameters()  # using the current default values
+        # input values for the material
+        parameters['E'] = E
+        parameters['nu'] = nu
+        # definition of the beam and mesh
+        parameters['dim'] = 3
+        parameters['mesh_density'] = 4  # number of elements in vertical direction
+        parameters['height'] = 300  # in mm
+        parameters['length'] = 2000  # in mm
+        parameters['width'] = 150  # in mm
+        parameters['log_level'] = 'WARNING'
+        # displacement load in the center of the beam
+        displacement = -10  # displacement load in the center of the beam in mm
 
-    # setting up the problem
-    experiment = fenics_concrete.ConcreteBeamExperiment(parameters)
-    problem = fenics_concrete.LinearElasticity(experiment, parameters)
+        # setting up the problem
+        experiment = fenics_concrete.ConcreteBeamExperiment(parameters)
+        problem = fenics_concrete.LinearElasticity(experiment, parameters)
 
-    # applying the load
-    problem.experiment.apply_displ_load(displacement)
+        # applying the load
+        problem.experiment.apply_displ_load(displacement)
 
-    # applying the stress sensor
-    stress_sensor = fenics_concrete.sensors.StressSensor(df.Point(parameters.length/2, 0, 0))
-    problem.add_sensor(stress_sensor)
+        # applying the stress sensor
+        stress_sensor = fenics_concrete.sensors.StressSensor(df.Point(parameters.length / 2, 0, 0))
+        problem.add_sensor(stress_sensor)
 
-    # solving the problem
-    problem.solve(t=0)  # solving this
+        # solving the problem
+        problem.solve(t=0)  # solving this
 
-    # results for last (only) load step
-    stress_tensor = problem.sensors[stress_sensor.name].data[-1]
-    stress_in_x = stress_tensor[0]
+        # results for last (only) load step
+        stress_tensor = problem.sensors[stress_sensor.name].data[-1]
+        stress_in_x = stress_tensor[0]
 
-    return stress_in_x
-
+        return stress_in_x
+# def three_point_bending_example(E, nu):
+#     """Example of a linear elastic three point bending test
+#
+#     Parameters
+#     ----------
+#         E : float
+#             Young's modulus in N/mm²
+#         nu : float
+#             Poisson's ratio
+#
+#     Returns
+#     -------
+#         stress_in_x : float
+#             Stress in x direction in the center at the bottom, where the maximum stress is expected
+#     """
+#     # setting up the simulation parameters
+#     parameters = fenics_concrete.Parameters()  # using the current default values
+#     # input values for the material
+#     parameters['E'] = E
+#     parameters['nu'] = nu
+#     # definition of the beam and mesh
+#     parameters['dim'] = 3
+#     parameters['mesh_density'] = 4  # number of elements in vertical direction
+#     parameters['height'] = 300  # in mm
+#     parameters['length'] = 2000  # in mm
+#     parameters['width'] = 150  # in mm
+#     parameters['log_level'] = 'WARNING'
+#     # displacement load in the center of the beam
+#     displacement = -10  # displacement load in the center of the beam in mm
+#
+#     # setting up the problem
+#     experiment = fenics_concrete.ConcreteBeamExperiment(parameters)
+#     problem = fenics_concrete.LinearElasticity(experiment, parameters)
+#
+#     # applying the load
+#     problem.experiment.apply_displ_load(displacement)
+#
+#     # applying the stress sensor
+#     stress_sensor = fenics_concrete.sensors.StressSensor(df.Point(parameters.length / 2, 0, 0))
+#     problem.add_sensor(stress_sensor)
+#
+#     # solving the problem
+#     problem.solve(t=0)  # solving this
+#
+#     # results for last (only) load step
+#     stress_tensor = problem.sensors[stress_sensor.name].data[-1]
+#     stress_in_x = stress_tensor[0]
+#
+#     return stress_in_x
 
 # example of how to use this function
 # defining the material parameters
-E = 30000  # N/mm²
-nu = 0.2
-stress = three_point_bending_example(E, nu)
-# resulting stress in x direction in the bottom center of the beam
-print(stress)
+# E = 30000  # N/mm²
+# nu = 0.2
+# stress = three_point_bending_example(E, nu)
+# # resulting stress in x direction in the bottom center of the beam
+# print(stress)

--- a/usecases/Concrete/knowledgeGraph/emodul/emodul_query.py
+++ b/usecases/Concrete/knowledgeGraph/emodul/emodul_query.py
@@ -1,6 +1,6 @@
 from xml.dom.minidom import NamedNodeMap
 import rdflib
-from SPARQLWrapper import SPARQLWrapper
+#from SPARQLWrapper import SPARQLWrapper
 from pathlib import Path
 import os
 import sys


### PR DESCRIPTION
Implemented posterior predictive for the three point bending test. The posterior predictive works currently but the following needs to be considered:
- Bypassed querying the KG for the Emod test metadata. KG doesnt work as of now.
- Wrote a basic posterior predictive module. Plan to implement in Probeye too.
- Just the linear hooke's law used to get the calibrated E for now. 
- Currently the the calibrated results are not saved as KG and its not queried. Primarily because:
      - My calibration scripts uses Torch, but it is removed from Probeye (which I didnt know surprisingly). So I am still using older version of probeye (hence no rdf capabilities).
- If the forward model comes as a conda package with its own dependancies, how it is planned to merge with the dependencies of  KG development? 
caution : May not be the most elegant code, but it works. 